### PR TITLE
fix: 🐛 Tryggere håndtering av manifest URLer

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,7 @@ function extractPathsFromCRAManifest(manifestObject: ManifestObject): string[] {
 	const fileList = Object.entries(files).map(([name, path]) => ({name, path})) as {name: string, path: string}[];
 
 	entrypoints.forEach((entrypoint) => {
-		const matchingFile = fileList.find(file => file.path.includes(entrypoint));
+		const matchingFile = fileList.find(file => file.path.endsWith(entrypoint));
 
 		if (matchingFile) {
 			pathsToLoad.push(matchingFile.path);


### PR DESCRIPTION
Bedre å bruke endsWith() for å sjekke etter filer, slik at man ikke med et uhell henter .map filer.
