### PR TITLE
fix: 🐛 advarsel om man forsøker async-lasting av definiert app

### DIFF
--- a/src/async/async-navspa.tsx
+++ b/src/async/async-navspa.tsx
@@ -1,7 +1,8 @@
 import React, {ReactNode} from "react";
 import loadjs from 'loadjs';
 import {createAssetManifestParser, joinPaths} from "./utils";
-import {importer as importerSync} from '../navspa'
+import {importer as importerSync, scope, scopeV2 } from '../navspa'
+import {asyncLoadingOfDefinedApp} from "../feilmelding";
 
 
 const ASSET_MANIFEST_NAME = 'asset-manifest.json';
@@ -34,6 +35,9 @@ async function loadAssets(config: PreloadConfig): Promise<void> {
     const assetManifestParser = config.assetManifestParser || createAssetManifestParser(config.appBaseUrl);
 
     if (!loadjs.isDefined(loadJsBundleId)) {
+        if (process.env.NODE_ENV === 'development' && (scope[config.appName] || scopeV2[config.appName])) {
+            console.warn(asyncLoadingOfDefinedApp(config.appName))
+        }
         const assets: string[] = await fetchAssetUrls(config.appBaseUrl, assetManifestParser)
         if (!loadjs.isDefined(loadJsBundleId)) {
             await loadjs(assets, loadJsBundleId, {returnPromise: true})

--- a/src/async/async-navspa.tsx
+++ b/src/async/async-navspa.tsx
@@ -30,19 +30,20 @@ function fetchAssetUrls(appBaseUrl: string, assetManifestParser: AssetManifestPa
         .then(manifest => assetManifestParser(manifest));
 }
 
-async function loadAssets(config: PreloadConfig): Promise<void> {
+const loadingStatus: { [key: string]: Promise<void> } = {};
+function loadAssets(config: PreloadConfig): Promise<void> {
     const loadJsBundleId = createLoadJsBundleId(config.appName);
-    const assetManifestParser = config.assetManifestParser || createAssetManifestParser(config.appBaseUrl);
-
-    if (!loadjs.isDefined(loadJsBundleId)) {
+    if (!loadingStatus[loadJsBundleId]) {
         if (process.env.NODE_ENV === 'development' && (scope[config.appName] || scopeV2[config.appName])) {
             console.warn(asyncLoadingOfDefinedApp(config.appName))
         }
-        const assets: string[] = await fetchAssetUrls(config.appBaseUrl, assetManifestParser)
-        if (!loadjs.isDefined(loadJsBundleId)) {
-            await loadjs(assets, loadJsBundleId, {returnPromise: true})
-        }
+
+        const assetManifestParser = config.assetManifestParser || createAssetManifestParser(config.appBaseUrl);
+        loadingStatus[loadJsBundleId] = fetchAssetUrls(config.appBaseUrl, assetManifestParser)
+                .then((assets) => loadjs(assets, loadJsBundleId, {returnPromise: true}))
     }
+
+    return loadingStatus[loadJsBundleId];
 }
 
 export function preload(config: PreloadConfig) {

--- a/src/feilmelding.ts
+++ b/src/feilmelding.ts
@@ -2,3 +2,8 @@ export const v2Unmount = (app: string) => `
 NAVSPA-appen '${app}' bruker en eldre versjon av NAVSPA for eksportering.
 Denne har ett kjent problem med unmounting av komponenten, og det er derfor anbefalt å oppdatere til nyeste versjon.
 `.trim();
+
+export const asyncLoadingOfDefinedApp = (app: string) => `
+NAVSPA-appen '${app}' ser ut til å være lastet inn via statiske script/link tags fra før av.
+Man kan derfor bruke synkron innlasting av denne appen, eller fjerne innlastingen fra index.html.
+`.trim()

--- a/src/navspa.tsx
+++ b/src/navspa.tsx
@@ -17,8 +17,8 @@ type NAVSPAApp = {
 	unmount(element: HTMLElement): void;
 }
 
-const scope: DeprecatedNAVSPAScope = (global as any)['NAVSPA'] = (global as any)['NAVSPA'] || {}; // tslint:disable-line
-const scopeV2: NAVSPAScope = (global as any)['NAVSPA-V2'] = (global as any)['NAVSPA-V2'] || {}; // tslint:disable-line
+export const scope: DeprecatedNAVSPAScope = (global as any)['NAVSPA'] = (global as any)['NAVSPA'] || {}; // tslint:disable-line
+export const scopeV2: NAVSPAScope = (global as any)['NAVSPA-V2'] = (global as any)['NAVSPA-V2'] || {}; // tslint:disable-line
 
 export function eksporter<PROPS>(name: string, component: React.ComponentType<PROPS>) {
 	scope[name] = (element: HTMLElement, props: PROPS) => {


### PR DESCRIPTION
om konsumenten bruker async importering er preloading av app som er
allerede lastet inn via script/link tags så vil de nå få en advarsel. På
denne måten får folk en indikasjon på at de kan rydde opp i index.html
om de ønsker å bruker async lasting av appen. Konsekvensen av å ignorer
advarslen er bare at assets blir lastet dobbelt; via index.html og
loadjs senere. Vi logger advarslen kun under development slik at vi ikke
forkludrer prod-byggene med unødvendig logging

**UPDATE:**
skriver om til promise-map for å holde styr hvilke apper man har startet
å laste inn. Dette gjøres fordi
`loadjs.isDefined`/`loadjs.ready`-oppsettet ikke fungerte optimalt og
man kunne komme i situasjoner hvor man prøvde å rendre appen mens
preloading fortsatt pågikk. `loadjs.isDefined`-guarden indikerte da at
appen var lastet inn siden det skjer synkront med kallet til loadjs,
mens den i realiteten ikke var klar enda. Ved bruk av ett promise-map så
erstatter vi `loadjs.isDefined`-guarden med vår egen logikk, som
returnerer eksisterene promise (e.g pågående eller ferdig innlasting)
ved påfølgende forsøk på å laste inn en app. Dette gir oss også deduping
av henting av assets og innlasting av ressurser som en side-effekt, men
introduserer en global variabel.