### PR TITLE
fix: 🐛 legge til feilmelding om navspa-appen ikke finnes

### DIFF
--- a/src/feilmelding.ts
+++ b/src/feilmelding.ts
@@ -1,3 +1,15 @@
+export const ukjentApp = (app: string) => `
+NAVSPA-appen '${app}' er ikke lastet inn.
+
+Lastet vha script tags: 
+  Sjekk at script-tagen for navspa-appen ligger ovenfor applikasjons script-taggen.
+  Dette for å sikre at navspa-appen blir lastet inn før applikasjonen deres forsøker å bruke den. 
+
+Lastet vha async:
+  Sjekk at urlene som blir forsøkt lastet inn ser riktige ut. 
+  E.g henters asset-manifest fra riktig sted, og gjøres utledning av assets-urlene riktig.
+`.trim();
+
 export const v2Unmount = (app: string) => `
 NAVSPA-appen '${app}' bruker en eldre versjon av NAVSPA for eksportering.
 Denne har ett kjent problem med unmounting av komponenten, og det er derfor anbefalt å oppdatere til nyeste versjon.

--- a/src/navspa.tsx
+++ b/src/navspa.tsx
@@ -37,7 +37,11 @@ export function eksporter<PROPS>(name: string, component: React.ComponentType<PR
 export function importer<P>(name: string, wrapperClassName?: string): React.ComponentType<P> {
 	let app: NAVSPAApp = scopeV2[name];
 	if (!app) {
-		console.error(Feilmelding.v2Unmount(name))
+		if (scope[name]) {
+			console.error(Feilmelding.v2Unmount(name));
+		} else {
+			console.error(Feilmelding.ukjentApp(name));
+		}
 		app = {
 			mount: scope[name],
 			unmount(element: HTMLElement) {


### PR DESCRIPTION
i tilfeller hvor innlasting av navspa appen har feilet ville man tidligere få en feilmelding om at man brukte en gammel versjon av biblioteket. 
Dette var misvisende, så vi sjekker nå hvorvidt appen finnes i legacy-scopet før denne feilmeldingen vises. 
Om appen ikke finnes i noen av scopene så logger vi en dedikert feilmelding om at appen ikke ble funnet
