### PR TITLE
feat: 🎸 legge til muligheten for egendefinert feilvisning

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ I parent-app kan man så gjøre følgende;
 ```typescript jsx
 import NAVSPA from '@navikt/navspa';
 const Child1 = NAVSPA.importer<ChildProps>('child1');
-const Child2 = NAVSPA.importer<ChildProps>('child2', 'wrapper-classname');
+const Child2 = NAVSPA.importer<ChildProps>('child2', {
+    wrapperClassName: 'wrapper-classname',
+    feilmelding: <Alertstripe>Feil ved innlasting av child2</Alertstripe>
+});
 
 function Wrapper() {
   return (
@@ -56,7 +59,10 @@ const AsyncChild2 = AsyncNavspa.importer<ChildProps>({
     appName: 'child-2',
     appBaseUrl: 'https://url-to-microfrontend2.com/',
     assetManifestParser:  (manifest: { [k: string]: any }) => {/*...*/},
-    wrapperClassName: 'wrapper-classname',
+    config: {
+        wrapperClassName: 'wrapper-classname',
+        feilmelding: <Alertstripe>Feil ved innlasting av child-2</Alertstripe>
+    },
     loader: (<div>Laster child 2...</div>),
 });
 

--- a/example/index.html
+++ b/example/index.html
@@ -20,6 +20,7 @@
         // Nytt oppsett
         window['NAVSPA-V2'].newapp = {
             mount: (element, props) => {
+                element.innerHTML = '';
                 const header = document.createElement('h1');
                 header.textContent = `Hello ${props.appname} from new`;
                 element.appendChild(header);

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -9,11 +9,21 @@ interface DecoratorProps {
 const Dekorator = Navspa.importer<DecoratorProps>('internarbeidsflatefs');
 const OldApp = Navspa.importer<DecoratorProps>('oldapp');
 const NewApp = Navspa.importer<DecoratorProps>('newapp');
+const ErrorApp = Navspa.importer<DecoratorProps>('errorapp', {
+	// feilmelding: null
+	// feilmelding: 'bare en string er lov'
+	feilmelding: <h1>Stor statisk feilmelding</h1>
+});
 
 const asyncConfig: AsyncSpaConfig = {
 	appName: 'cra-test',
 	appBaseUrl: 'http://localhost:5000',
-	loader: (<div>Laster...</div>)
+	loader: (<div>Laster...</div>),
+	config: {
+		// feilmelding: null
+		// feilmelding: 'Kunne ikke laste inn cra-test'
+		feilmelding: <h1>Kunne ikke laste inn cra-test</h1>
+	}
 };
 
 const AsyncApp = AsyncNavspa.importer(asyncConfig);
@@ -38,6 +48,7 @@ function App() {
 			{mount && <OldApp appname="world"/>}
 			{mount && <NewApp appname="world"/>}
 			{mountAsync && mount && <AsyncApp/>}
+			<ErrorApp />
 		</>
 	);
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-dom": "^16.14.0",
     "serve": "^11.3.2",
     "ts-jest": "^26.1.3",
-    "typescript": "^3.5.3"
+    "typescript": "^3.9.9"
   },
   "jest": {
     "transform": {

--- a/src/async/async-navspa.tsx
+++ b/src/async/async-navspa.tsx
@@ -1,7 +1,7 @@
 import React, {ReactNode} from "react";
 import loadjs from 'loadjs';
 import {createAssetManifestParser, joinPaths} from "./utils";
-import {importer as importerSync, scope, scopeV2 } from '../navspa'
+import {importer as importerSync, NAVSPAAppConfig, scope, scopeV2} from '../navspa'
 import {asyncLoadingOfDefinedApp} from "../feilmelding";
 
 
@@ -16,7 +16,7 @@ export interface PreloadConfig {
 }
 
 export interface AsyncSpaConfig extends PreloadConfig {
-    wrapperClassName?: string;
+    config?: NAVSPAAppConfig;
     loader?: NonNullable<ReactNode>;
 }
 
@@ -54,7 +54,7 @@ export function preload(config: PreloadConfig) {
 export function importerLazy<P>(config: AsyncSpaConfig): Promise<{ default: React.ComponentType<P> }> {
     return loadAssets(config)
         .catch(console.error)
-        .then(() => ({ default: importerSync<P>(config.appName, config.wrapperClassName) }));
+        .then(() => ({ default: importerSync<P>(config.appName, config.config) }));
 }
 
 export function importer<P>(config: AsyncSpaConfig): React.ComponentType<P> {

--- a/src/navspa.tsx
+++ b/src/navspa.tsx
@@ -12,6 +12,11 @@ interface NAVSPAScope {
 	[name: string]: NAVSPAApp;
 }
 
+export interface NAVSPAAppConfig {
+	wrapperClassName?: string;
+	feilmelding?: React.ReactNode;
+}
+
 type NAVSPAApp = {
 	mount(element: HTMLElement, props: any): void;
 	unmount(element: HTMLElement): void;
@@ -34,7 +39,12 @@ export function eksporter<PROPS>(name: string, component: React.ComponentType<PR
 	}
 }
 
-export function importer<P>(name: string, wrapperClassName?: string): React.ComponentType<P> {
+export function importer<P>(name: string, config?: NAVSPAAppConfig): React.ComponentType<P> {
+	const appconfig: NAVSPAAppConfig = {
+		...(config ?? {}),
+		feilmelding: config?.feilmelding === undefined ? <>Feil i {name}</> : config?.feilmelding
+	}
+
 	let app: NAVSPAApp = scopeV2[name];
 	if (!app) {
 		console.error(Feilmelding.v2Unmount(name))
@@ -46,14 +56,14 @@ export function importer<P>(name: string, wrapperClassName?: string): React.Comp
 		};
 	}
 
-	return (props: P) => <NavSpa name={name} navSpaApp={app} navSpaProps={props} wrapperClassName={wrapperClassName}/>;
+	return (props: P) => <NavSpa name={name} navSpaApp={app} navSpaProps={props} config={appconfig} />;
 }
 
 interface NavSpaWrapperProps<P> {
 	name: string;
 	navSpaApp: NAVSPAApp;
 	navSpaProps: P;
-	wrapperClassName?: string;
+	config: NAVSPAAppConfig;
 }
 
 interface NavSpaState {
@@ -105,9 +115,9 @@ class NavSpa<P> extends React.Component<NavSpaWrapperProps<P>, NavSpaState> {
 
 	public render() {
 		if (this.state.hasError) {
-			return <div className="navspa--applikasjonsfeil">Feil i {this.props.name}</div>;
+			return <div className="navspa--applikasjonsfeil">{this.props.config.feilmelding}</div>;
 		}
-		return <div className={this.props.wrapperClassName} ref={this.saveRef}/>;
+		return <div className={this.props.config.wrapperClassName} ref={this.saveRef}/>;
 	}
 
 	private saveRef = (mountPoint: HTMLDivElement) => {


### PR DESCRIPTION
wrapperClassName flyttet inn i generisk config-objekt for å unngå at importerer funksjonen bare fikk enda ett argument. Deretter er det lagt til muligheten for å sende inn `feilmelding` i dette objektet (se endringer i README)

BREAKING CHANGE: 🧨 wrapperClassName flyttet inn i config-objekt
