### PR TITLE
feat: Add react-dom/client to external modules array in rollup config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/navspa",
-  "version": "7.3.0",
+  "version": "7.5.0",
   "description": "Bibliotek for eksportering og importering av hele applikasjoner som react-komponetner.",
   "repository": "github:navikt/navspa",
   "homepage": "https://github.com/navikt/navspa",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,12 +13,13 @@ export default defineConfig({
       fileName: "index",
     },
     rollupOptions: {
-      external: ["react", "react-dom", "react/jsx-runtime"],
+      external: ["react", "react-dom","react-dom/client", "react/jsx-runtime"],
       output: {
         globals: {
           react: "React",
           "react/jsx-runtime": "react/jsx-runtime",
           "react-dom": "ReactDOM",
+          "react-dom/client": "ReactDOM",
         },
       },
     },


### PR DESCRIPTION
Vi har et problem hvor appene våre ikke får oppdatert minor/patch av `react` og `react-dom`, selv om de oppgraderte versjonene egentlig støttes av denne pakkens `peerDependencies`. Problemet er at `react-dom/client` bundles inn i `navspa` under bygging, som medfører en feil av typen

```
Incompatible React versions: The "react" and "react-dom" packages must have the exact same version.
...
```

Da får vi spesielt problemer med Dependabot, som hele tiden må leve med røde PRer når den forsøker patche opp React.

Med denne PRen prøver jeg å legge til `react-dom/client` i `external` i `rollupOptions` slik at dette ikke bundles med pakken. Jeg tror og håper dette skal fungere, ser ikke noe tegn til feil i `dist/` nå i alle fall :smile: 